### PR TITLE
build: change exposer base image

### DIFF
--- a/.github/workflows/on_push_master.yml
+++ b/.github/workflows/on_push_master.yml
@@ -79,7 +79,7 @@ jobs:
         run: ssh development '
           sudo docker rm -f $(docker ps -aqf "name=clinic-frontend") || true &&
           sudo docker pull ghcr.io/altera-capston-41/frontend:latest &&
-          sudo docker run -dp 19030:8000 --name clinic-frontend ghcr.io/altera-capston-41/frontend:latest'
+          sudo docker run -dp 19030:3000 --name clinic-frontend ghcr.io/altera-capston-41/frontend:latest'
 
       - name: restart container
         run: ssh development '

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,10 @@ COPY . .
 RUN npm install && npm run lint && npm run build
 
 # runner -- automatically exposed at 3000
-FROM abhin4v/hastatic:latest
-COPY --from=builder /app/dist /opt/dist
-WORKDIR /opt/dist
+FROM node:14.19-alpine3.14
+RUN npm install -g serve
+COPY --from=builder /app/dist /app
+WORKDIR /app
+EXPOSE 5000
 
-CMD [ "usr/bin/hastatic" ]
+CMD [ "serve", "-s", "." ]


### PR DESCRIPTION
## Overview
Based on actions log, tracked deployment was failed because the exposer command not found. It can be fixed by replacing binary path. 

But, it'll raise a new bug of SPAs. If user visits the page except the root page, the app will respond `page not found`. Therefore, the right way is using a nodejs based SPA exposer, `serve`.